### PR TITLE
feat(config): Add fiat, gate, and igor configs

### DIFF
--- a/base/clouddriver/base/deployment.yml
+++ b/base/clouddriver/base/deployment.yml
@@ -54,4 +54,3 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
-

--- a/base/clouddriver/base/deployment.yml
+++ b/base/clouddriver/base/deployment.yml
@@ -2,20 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clouddriver
-  labels:
-    app.kubernetes.io/name: clouddriver
-    app.kubernetes.io/instance: clouddriver
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: clouddriver
-      app.kubernetes.io/instance: clouddriver
   template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: clouddriver
-        app.kubernetes.io/instance: clouddriver
     spec:
       containers:
       - env:

--- a/base/clouddriver/base/kustomization.yml
+++ b/base/clouddriver/base/kustomization.yml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
 - deployment.yml
 - service.yml
+commonLabels:
+  app.kubernetes.io/instance: clouddriver
+  app.kubernetes.io/name: clouddriver

--- a/base/clouddriver/base/service.yml
+++ b/base/clouddriver/base/service.yml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app.kubernetes.io/name: clouddriver
-    app.kubernetes.io/instance: clouddriver
   name: clouddriver
 spec:
   ports:

--- a/base/config/spinnaker.yml
+++ b/base/config/spinnaker.yml
@@ -1,4 +1,10 @@
 services:
+  # Even though clouddriver is deployed in HA mode, other services may not know
+  # this and simply look for service.clouddriver. To account for this use case,
+  # we'll point the generic 'clouddriver' at clouddriver-rw.
+  clouddriver:
+    baseUrl: http://clouddriver-rw.spinnaker:7002
+    enabled: true
   clouddriverCaching:
     baseUrl: http://clouddriver-caching.spinnaker:7002
     enabled: true
@@ -17,8 +23,20 @@ services:
   echoWorker:
     baseUrl: http://echo-worker.spinnaker:8089
     enabled: true
+  fiat:
+    baseUrl: http://fiat.spinnaker:7003
+    enabled: true
   front50:
     baseUrl: http://front50.spinnaker:8080
+    enabled: true
+  # TODO(ezimanyi): The gate URL might be http:// or https://. Figure out how
+  # to handle both cases. (Or, alternately, determine if we need this URL here
+  # at all given that other services should not be sending requests to gate.)
+  gate:
+    baseUrl: https://gate.spinnaker:8084
+    enabled: true
+  igor:
+    baseUrl: http://igor.spinnaker:8088
     enabled: true
   orca:
     baseUrl: http://orca.spinnaker:8083

--- a/base/echo/base/deployment.yml
+++ b/base/echo/base/deployment.yml
@@ -2,20 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echo
-  labels:
-    app.kubernetes.io/name: echo
-    app.kubernetes.io/instance: echo
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: echo
-      app.kubernetes.io/instance: echo
   template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: echo
-        app.kubernetes.io/instance: echo
     spec:
       containers:
       - env:

--- a/base/echo/base/deployment.yml
+++ b/base/echo/base/deployment.yml
@@ -54,4 +54,3 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
-

--- a/base/echo/base/kustomization.yml
+++ b/base/echo/base/kustomization.yml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
 - deployment.yml
 - service.yml
+commonLabels:
+  app.kubernetes.io/instance: echo
+  app.kubernetes.io/name: echo

--- a/base/echo/base/service.yml
+++ b/base/echo/base/service.yml
@@ -1,16 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app.kubernetes.io/name: echo
-    app.kubernetes.io/instance: echo
   name: echo
 spec:
   ports:
   - port: 8089
     protocol: TCP
     targetPort: 8089
-  selector:
-    app.kubernetes.io/name: echo
-    app.kubernetes.io/instance: echo
   type: ClusterIP

--- a/base/fiat/base/deployment.yml
+++ b/base/fiat/base/deployment.yml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fiat
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - env:
+        - name: JAVA_OPTS
+          value: -XX:MaxRAMPercentage=80.0
+        - name: SPRING_PROFILES_ACTIVE
+          value: local
+        image: gcr.io/spinnaker-marketplace/fiat:spinnaker-master-latest-unvalidated
+        name: fiat
+        ports:
+        - name: traffic-port
+          containerPort: 7003
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            port: traffic-port
+            path: /health
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 500m
+        volumeMounts:
+        - mountPath: /opt/spinnaker/config
+          name: fiat-config-volume
+        - mountPath: /var/secrets
+          name: spinnaker-secrets-volume
+      terminationGracePeriodSeconds: 720
+      volumes:
+      - name: fiat-config-volume
+        secret:
+          secretName: fiat-config
+      - name: spinnaker-secrets-volume
+        secret:
+          secretName: spinnaker-secrets

--- a/base/fiat/base/kustomization.yml
+++ b/base/fiat/base/kustomization.yml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yml
+- service.yml
+commonLabels:
+  app.kubernetes.io/name: fiat
+  app.kubernetes.io/instance: fiat

--- a/base/fiat/base/service.yml
+++ b/base/fiat/base/service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fiat
+spec:
+  ports:
+  - port: 7003
+    protocol: TCP
+    targetPort: 7003
+  type: ClusterIP

--- a/base/fiat/kustomization.yml
+++ b/base/fiat/kustomization.yml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./base
+secretGenerator:
+- files: []
+  name: fiat-config

--- a/base/front50/base/deployment.yml
+++ b/base/front50/base/deployment.yml
@@ -50,4 +50,3 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
-

--- a/base/front50/base/deployment.yml
+++ b/base/front50/base/deployment.yml
@@ -2,20 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: front50
-  labels:
-    app.kubernetes.io/name: front50
-    app.kubernetes.io/instance: front50
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: front50
-      app.kubernetes.io/instance: front50
   template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: front50
-        app.kubernetes.io/instance: front50
     spec:
       containers:
       - env:

--- a/base/front50/base/kustomization.yml
+++ b/base/front50/base/kustomization.yml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
 - deployment.yml
 - service.yml
+commonLabels:
+  app.kubernetes.io/name: front50
+  app.kubernetes.io/instance: front50

--- a/base/front50/base/service.yml
+++ b/base/front50/base/service.yml
@@ -1,16 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app.kubernetes.io/name: front50
-    app.kubernetes.io/instance: front50
   name: front50
 spec:
   ports:
   - port: 8080
     protocol: TCP
     targetPort: 8080
-  selector:
-    app.kubernetes.io/name: front50
-    app.kubernetes.io/instance: front50
   type: ClusterIP

--- a/base/gate/base/deployment.yml
+++ b/base/gate/base/deployment.yml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gate
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - env:
+        - name: JAVA_OPTS
+          value: -XX:MaxRAMPercentage=80.0
+        - name: SPRING_PROFILES_ACTIVE
+          value: local
+        image: gcr.io/spinnaker-marketplace/gate:spinnaker-master-latest-unvalidated
+        name: gate
+        ports:
+        - name: traffic-port
+          containerPort: 8084
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            # TODO(ezimanyi): we need some way of making this scheme configurable
+            # so the health check passes without SSL enabled.
+            scheme: HTTPS
+            port: traffic-port
+            path: /health
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 500m
+        volumeMounts:
+        - mountPath: /opt/spinnaker/config
+          name: gate-config-volume
+        - mountPath: /var/secrets
+          name: spinnaker-secrets-volume
+      terminationGracePeriodSeconds: 720
+      volumes:
+      - name: gate-config-volume
+        secret:
+          secretName: gate-config
+      - name: spinnaker-secrets-volume
+        secret:
+          secretName: spinnaker-secrets

--- a/base/gate/base/kustomization.yml
+++ b/base/gate/base/kustomization.yml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yml
+- service.yml
+commonLabels:
+  app.kubernetes.io/name: gate
+  app.kubernetes.io/instance: gate

--- a/base/gate/base/service.yml
+++ b/base/gate/base/service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gate
+spec:
+  ports:
+  - port: 8084
+    protocol: TCP
+    targetPort: 8084
+  type: ClusterIP

--- a/base/gate/kustomization.yml
+++ b/base/gate/kustomization.yml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./base
+secretGenerator:
+- files: []
+  name: gate-config

--- a/base/igor/base/deployment.yml
+++ b/base/igor/base/deployment.yml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: igor
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - env:
+        - name: JAVA_OPTS
+          value: -XX:MaxRAMPercentage=80.0
+        - name: SPRING_PROFILES_ACTIVE
+          value: local
+        image: gcr.io/spinnaker-marketplace/igor:spinnaker-master-latest-unvalidated
+        name: igor
+        ports:
+        - name: traffic-port
+          containerPort: 8088
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            port: traffic-port
+            path: /health
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /opt/spinnaker/config
+          name: igor-config-volume
+        - mountPath: /var/secrets
+          name: spinnaker-secrets-volume
+      terminationGracePeriodSeconds: 720
+      volumes:
+      - name: igor-config-volume
+        secret:
+          secretName: igor-config
+      - name: spinnaker-secrets-volume
+        secret:
+          secretName: spinnaker-secrets

--- a/base/igor/base/kustomization.yml
+++ b/base/igor/base/kustomization.yml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yml
+- service.yml
+commonLabels:
+  app.kubernetes.io/name: igor
+  app.kubernetes.io/instance: igor

--- a/base/igor/base/service.yml
+++ b/base/igor/base/service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: igor
+spec:
+  ports:
+  - port: 8088
+    protocol: TCP
+    targetPort: 8088
+  type: ClusterIP

--- a/base/igor/kustomization.yml
+++ b/base/igor/kustomization.yml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./base
+secretGenerator:
+- files: []
+  name: igor-config

--- a/base/kustomization.yml
+++ b/base/kustomization.yml
@@ -3,7 +3,10 @@ kind: Kustomization
 resources:
 - ./clouddriver
 - ./echo
+- ./fiat
 - ./front50
+- ./igor
+- ./gate
 - ./orca
 commonLabels:
   app.kubernetes.io/component: server
@@ -22,7 +25,19 @@ secretGenerator:
 - behavior: merge
   files:
   - config/spinnaker.yml
+  name: fiat-config
+- behavior: merge
+  files:
+  - config/spinnaker.yml
   name: front50-config
+- behavior: merge
+  files:
+  - config/spinnaker.yml
+  name: gate-config
+- behavior: merge
+  files:
+  - config/spinnaker.yml
+  name: igor-config
 - behavior: merge
   files:
   - config/spinnaker.yml

--- a/base/orca/base/deployment.yml
+++ b/base/orca/base/deployment.yml
@@ -2,20 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orca
-  labels:
-    app.kubernetes.io/name: orca
-    app.kubernetes.io/instance: orca
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: orca
-      app.kubernetes.io/instance: orca
   template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: orca
-        app.kubernetes.io/instance: orca
     spec:
       containers:
       - env:

--- a/base/orca/base/deployment.yml
+++ b/base/orca/base/deployment.yml
@@ -50,4 +50,3 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
-

--- a/base/orca/base/kustomization.yml
+++ b/base/orca/base/kustomization.yml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
 - deployment.yml
 - service.yml
+commonLabels:
+  app.kubernetes.io/name: orca
+  app.kubernetes.io/instance: orca

--- a/base/orca/base/service.yml
+++ b/base/orca/base/service.yml
@@ -1,16 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app.kubernetes.io/name: orca
-    app.kubernetes.io/instance: orca
   name: orca
 spec:
   ports:
   - port: 8083
     protocol: TCP
     targetPort: 8083
-  selector:
-    app.kubernetes.io/name: orca
-    app.kubernetes.io/instance: orca
   type: ClusterIP


### PR DESCRIPTION
* style(core): Fix newlines at end of files 

  This doesn't really matter, but I wanted to be consistent.

* refactor(core): Move all labels to the kustomization.yml file 

  In some places we're including labels directly in the kubernetes manifests, and in others we're adding these in the kustomization.yml.

  I propose to standardize on this:
  * The individual manifests won't have labels (or other label fields that kustomize can add)
  * The kustomizeation.yml alongside each service/deployment adds the necessary labels (generally the instance and name based on the service)
  * In the case of services that are always overridden by an HA version
  (ex: clouddriver) I still added raw 'clouddriver' labels in the base kustomization just so it would be valid on its own even if we are always adding different labels.

  The advantage is less duplication of labels (and reducing copy/paste mistakes of forgetting to update one label). The disadvantage is that it's a bit less clear exactly what labels get generated (ie, we no longer explicitly include a selector, etc.)

  To test this, I generated a full deployment manifest by running kustomize before and after, and found no differences. (Or rather I did find differences, but then I fixed them so that by the time you read this commit there are no differences.)

* feat(config): Add fiat, gate, and igor configs 

  There is nothing special that had to be considered for these services as far as HA; just adding the same YAML as we had for other non-HA services.

  (At some point we can decide whether to further factor things out to reduce copy-pase, but for now I think our initial decision to favor duplication over overly-complex factoring is still the correct one.)

  One complication for Gate is that the health check depends on whether it has HTTPS enabled, which depends on the halconfig. For now I've just made the check HTTPS enabled but we'll need to think about how to support both.
