### PR TITLE
refactor(service-discovery): exclude Gate from spinnaker.yml

### DIFF
--- a/service-discovery/spinnaker.yml
+++ b/service-discovery/spinnaker.yml
@@ -29,12 +29,6 @@ services:
   front50:
     baseUrl: http://front50.spinnaker:8080
     enabled: true
-  # TODO(ezimanyi): The gate URL might be http:// or https://. Figure out how
-  # to handle both cases. (Or, alternately, determine if we need this URL here
-  # at all given that other services should not be sending requests to gate.)
-  gate:
-    baseUrl: https://gate.spinnaker:8084
-    enabled: true
   igor:
     baseUrl: http://igor.spinnaker:8088
     enabled: true


### PR DESCRIPTION
Only Deck needs to know how to reach Gate, and we will handle that in an upcoming commit to Kleat.