### PR TITLE
feat(deck): Add deck to base kustomization

### DIFF
--- a/core/deck/base/deployment.yml
+++ b/core/deck/base/deployment.yml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deck
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - env:
+        - name: DECK_HOST
+          value: 0.0.0.0
+        - name: DECK_PORT
+          value: "9000"
+        envFrom:
+          - configMapRef:
+              name: deck-env
+        image: gcr.io/spinnaker-marketplace/deck:spinnaker-master-latest-unvalidated
+        name: deck
+        ports:
+        - name: traffic-port
+          containerPort: 9000
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 9000
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /opt/spinnaker/config
+          name: deck-config-volume
+        - mountPath: /var/secrets
+          name: spinnaker-secrets-volume
+      volumes:
+      - name: deck-config-volume
+        secret:
+          secretName: deck-config
+      - name: spinnaker-secrets-volume
+        secret:
+          secretName: spinnaker-secrets

--- a/core/deck/base/kustomization.yml
+++ b/core/deck/base/kustomization.yml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yml
+- service.yml
+commonLabels:
+  app.kubernetes.io/name: deck
+  app.kubernetes.io/instance: deck

--- a/core/deck/base/service.yml
+++ b/core/deck/base/service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deck
+spec:
+  ports:
+  - port: 9000
+    protocol: TCP
+    targetPort: 9000
+  type: ClusterIP

--- a/core/deck/kustomization.yml
+++ b/core/deck/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./base

--- a/core/kustomization.yml
+++ b/core/kustomization.yml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ./clouddriver
+- ./deck
 - ./echo
 - ./front50
 - ./igor

--- a/core/service-discovery/kustomization.yml
+++ b/core/service-discovery/kustomization.yml
@@ -4,6 +4,8 @@ secretGenerator:
 - files:
   - spinnaker.yml
   name: clouddriver-config
+- files: []
+  name: deck-config
 - files:
   - spinnaker.yml
   name: echo-config
@@ -30,3 +32,5 @@ secretGenerator:
   name: rosco-config
 - files: []
   name: spinnaker-secrets
+configMapGenerator:
+- name: deck-env


### PR DESCRIPTION
This commit adds deck to the base kustomization, and sets it up to read its environment from a config map that will be generated by kleat.