### PR TITLE
fix(monitoring): mount spinnaker-secrets in monitoring sidecar

### DIFF
--- a/monitoring/patches/shared/sidecar.yml
+++ b/monitoring/patches/shared/sidecar.yml
@@ -28,3 +28,5 @@ spec:
           name: spinnaker-monitoring-config-volume
         - mountPath: /opt/spinnaker-monitoring/registry
           name: spinnaker-monitoring-registry-volume
+        - mountPath: /var/secrets
+          name: spinnaker-secrets-volume


### PR DESCRIPTION
Since spinnaker-monitoring.yml may include secrets, for example paths to credentials for one's Stackdriver account, we should mount the spinnaker-secrets volume in the monitoring sidecar.