### PR TITLE
fix(service-discovery): default Fiat to disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ resources:
 - github.com/spinnaker/kustomization-base/kayenta
 ```
 
+Since the default
+[service discovery file](/core/service-discovery/spinnaker.yml) defaults
+Kayenta to disabled, you will need to configure a service discovery overrides
+file in your fork of spinnaker-config with the following block:
+
+```
+services:
+  kayenta:
+    enabled: true
+```
+
 To enable Fiat, ensure that `security.authz` is set to `true` in your hal
 config, and then ensure the Fiat kustomization is included in the `resources`
 block of your `kustomization.yml`:
@@ -163,6 +174,17 @@ block of your `kustomization.yml`:
 resources:
 - github.com/spinnaker/kustomization-base/core
 - github.com/spinnaker/kustomization-base/fiat
+```
+
+Since the default
+[service discovery file](/core/service-discovery/spinnaker.yml) defaults
+Fiat to disabled, you will need to configure a service discovery overrides file
+in your fork of spinnaker-config with the following block:
+
+```
+services:
+  fiat:
+    enabled: true
 ```
 
 #### Set the Spinnaker version

--- a/core/service-discovery/spinnaker.yml
+++ b/core/service-discovery/spinnaker.yml
@@ -31,7 +31,7 @@ services:
     enabled: true
   fiat:
     baseUrl: http://fiat.spinnaker:7003
-    enabled: true
+    enabled: false
   front50:
     baseUrl: http://front50.spinnaker:8080
     enabled: true


### PR DESCRIPTION
We have already defaulted the other optional service, Kayenta, to disabled. Let's do the same for Fiat and provide instructions on enabling these services.