### PR TITLE
refactor(core): remove redundant readinessProbe parameters

### DIFF
--- a/core/clouddriver/base/deployment.yml
+++ b/core/clouddriver/base/deployment.yml
@@ -22,10 +22,6 @@ spec:
           httpGet:
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         resources:
           requests:
             cpu: 800m

--- a/core/deck/base/deployment.yml
+++ b/core/deck/base/deployment.yml
@@ -24,10 +24,6 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 9000
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /opt/spinnaker/config
           name: deck-config-volume

--- a/core/echo/base/deployment.yml
+++ b/core/echo/base/deployment.yml
@@ -22,10 +22,6 @@ spec:
           httpGet:
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         resources:
           requests:
             cpu: 800m

--- a/core/front50/base/deployment.yml
+++ b/core/front50/base/deployment.yml
@@ -22,10 +22,6 @@ spec:
           httpGet:
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /opt/spinnaker/config
           name: front50-config-volume

--- a/core/gate/base/deployment.yml
+++ b/core/gate/base/deployment.yml
@@ -25,10 +25,6 @@ spec:
             scheme: HTTPS
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         resources:
           requests:
             memory: 1Gi

--- a/core/igor/base/deployment.yml
+++ b/core/igor/base/deployment.yml
@@ -22,10 +22,6 @@ spec:
           httpGet:
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /opt/spinnaker/config
           name: igor-config-volume

--- a/core/orca/base/deployment.yml
+++ b/core/orca/base/deployment.yml
@@ -22,10 +22,6 @@ spec:
           httpGet:
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /opt/spinnaker/config
           name: orca-config-volume

--- a/core/rosco/base/deployment.yml
+++ b/core/rosco/base/deployment.yml
@@ -22,10 +22,6 @@ spec:
           httpGet:
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /opt/spinnaker/config
           name: rosco-config-volume

--- a/fiat/base/deployment.yml
+++ b/fiat/base/deployment.yml
@@ -22,10 +22,6 @@ spec:
           httpGet:
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         resources:
           requests:
             memory: 1Gi

--- a/kayenta/base/deployment.yml
+++ b/kayenta/base/deployment.yml
@@ -22,10 +22,6 @@ spec:
           httpGet:
             port: traffic-port
             path: /health
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         resources:
           requests:
             memory: 1Gi

--- a/monitoring/patches/shared/sidecar.yml
+++ b/monitoring/patches/shared/sidecar.yml
@@ -15,12 +15,8 @@ spec:
         - containerPort: 8008
           protocol: TCP
         readinessProbe:
-          failureThreshold: 3
-          periodSeconds: 10
-          successThreshold: 1
           tcpSocket:
             port: 8008
-          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /opt/spinnaker-monitoring/filters
           name: spinnaker-monitoring-filters-volume


### PR DESCRIPTION
Do not specify default values for readinessProbe parameters.
Source: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/