### PR TITLE
feat(config): add default security context

### DIFF
--- a/core/clouddriver/base/deployment.yml
+++ b/core/clouddriver/base/deployment.yml
@@ -31,6 +31,8 @@ spec:
           name: clouddriver-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: clouddriver-config-volume
@@ -39,3 +41,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/core/deck/base/deployment.yml
+++ b/core/deck/base/deployment.yml
@@ -29,6 +29,8 @@ spec:
           name: deck-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       volumes:
       - name: deck-config-volume
         secret:
@@ -36,3 +38,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/core/echo/base/deployment.yml
+++ b/core/echo/base/deployment.yml
@@ -31,6 +31,8 @@ spec:
           name: echo-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: echo-config-volume
@@ -39,3 +41,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/core/front50/base/deployment.yml
+++ b/core/front50/base/deployment.yml
@@ -27,6 +27,8 @@ spec:
           name: front50-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: front50-config-volume
@@ -35,3 +37,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/core/gate/base/deployment.yml
+++ b/core/gate/base/deployment.yml
@@ -34,6 +34,8 @@ spec:
           name: gate-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: gate-config-volume
@@ -42,3 +44,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/core/igor/base/deployment.yml
+++ b/core/igor/base/deployment.yml
@@ -27,6 +27,8 @@ spec:
           name: igor-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: igor-config-volume
@@ -35,3 +37,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/core/orca/base/deployment.yml
+++ b/core/orca/base/deployment.yml
@@ -27,6 +27,8 @@ spec:
           name: orca-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: orca-config-volume
@@ -35,3 +37,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/core/rosco/base/deployment.yml
+++ b/core/rosco/base/deployment.yml
@@ -27,6 +27,8 @@ spec:
           name: rosco-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: rosco-config-volume
@@ -35,3 +37,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/fiat/base/deployment.yml
+++ b/fiat/base/deployment.yml
@@ -31,6 +31,8 @@ spec:
           name: fiat-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: fiat-config-volume
@@ -39,3 +41,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/kayenta/base/deployment.yml
+++ b/kayenta/base/deployment.yml
@@ -31,6 +31,8 @@ spec:
           name: kayenta-config-volume
         - mountPath: /var/secrets
           name: spinnaker-secrets-volume
+        securityContext:
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 720
       volumes:
       - name: kayenta-config-volume
@@ -39,3 +41,7 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true


### PR DESCRIPTION
In general, we should configure `securityContext` to keep least privileges, like using non-root. The users may miss `securityContext` without default one configured, and also it would be cumbersome to configure them for each kustomization patch. That's why I believe this base kustomization should have a default `securityContext`.

And also, I've found @ezimanyi agreed with this idea in [Spinnaker Slack #kleat channel](https://spinnakerteam.slack.com/archives/C015GEUGRFS/p1594765667066700?thread_ts=1594248923.041300&cid=C015GEUGRFS).

