### PR TITLE
feat(security): Add fsGroup to all deployments

### DIFF
--- a/core/clouddriver/base/deployment.yml
+++ b/core/clouddriver/base/deployment.yml
@@ -45,3 +45,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/core/deck/base/deployment.yml
+++ b/core/deck/base/deployment.yml
@@ -42,3 +42,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/core/echo/base/deployment.yml
+++ b/core/echo/base/deployment.yml
@@ -45,3 +45,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/core/front50/base/deployment.yml
+++ b/core/front50/base/deployment.yml
@@ -41,3 +41,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/core/gate/base/deployment.yml
+++ b/core/gate/base/deployment.yml
@@ -48,3 +48,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/core/igor/base/deployment.yml
+++ b/core/igor/base/deployment.yml
@@ -41,3 +41,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/core/orca/base/deployment.yml
+++ b/core/orca/base/deployment.yml
@@ -41,3 +41,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/core/rosco/base/deployment.yml
+++ b/core/rosco/base/deployment.yml
@@ -41,3 +41,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/fiat/base/deployment.yml
+++ b/fiat/base/deployment.yml
@@ -45,3 +45,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000

--- a/kayenta/base/deployment.yml
+++ b/kayenta/base/deployment.yml
@@ -45,3 +45,4 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        fsGroup: 1000


### PR DESCRIPTION
Building on #25 

https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod

This is required when Kubernetes mounts in tokens like the AWS IRSA token into
containers, otherwise they get mounted owned by `root` and `clouddriver` can't
read them.
Similar story for other volume mounting though.

> Since `fsGroup` field is specified, all processes of the container are also
part of the supplementary group ID 2000. The owner for volume `/data/demo` and
any files created in that volume will be Group ID 2000.

Assists with: https://github.com/spinnaker/spinnaker/issues/3760

We use `fsGroup` but with ID same as the current Spinnaker service Dockerfile. 