### PR TITLE
feat(config): add configuration for release note generation with git-chglog

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,9 @@
+{{ range .Versions }}
+## Changelog
+
+{{ range .CommitGroups -}}
+{{ range .Commits -}}
+- [`{{ .Hash.Short }}`](https://github.com/spinnaker/kustomization-base/commit/{{ .Hash.Long }}): {{ .Header }}{{ if .Merge }}({{ .Merge.Ref }}){{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,13 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: Changelog
+  repository_url: https://github.com/spinnaker/kustomization-base
+options:
+  header:
+    # Only include commits whose message comply with the convention: "<type>(<scope>): <subject>"
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Generate release note
+        id: release_note
+        run: |
+          wget -O git-chglog https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64
+          sudo mv git-chglog /usr/local/bin
+          sudo chmod +x /usr/local/bin/git-chglog
+          version=${{ github.ref }}
+          version=${version#refs/tags/}
+          content=$(git-chglog "${version}")
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          echo "::set-output name=release_note::${content}"
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{ steps.release_note.outputs.release_note }}


### PR DESCRIPTION
## What

From: https://github.com/spinnaker/kleat/issues/121

This PR introduces a GitHub Actions workflow that generates release notes from the commits and then create GitHub Releases by triggering Git tag pushes.

The format mostly follows [Kleat's one](https://github.com/spinnaker/kleat/releases).

The only differences follow:

- commits aren't sorted in descending order
- commits whose message don't comply with the convention (`<type>(<scope>): <subject>`) aren't included in a release note

For example, the release note for `v0.1.0` looks like:

![Screenshot 2020-07-27 at 17 34 27](https://user-images.githubusercontent.com/21333876/88521908-95e45c00-d030-11ea-8aa9-e7a9069c95cd.png)

To the reviewers:

- If you have any concerns about the differences, let's discuss another method
- I use shell parameter expansion because GitHub Actions currently doesn't escape strings so we can't use multi-line strings without such substitution. For further details, take a look [this link](https://github.community/t/set-output-truncates-multiline-strings/16852/5).

## Context

We (@micnncim and @ezimanyi) have concluded from [the discussion](https://github.com/spinnaker/kleat/issues/121#issuecomment-661640043) that we should automate generation release notes for GitHub Releases with GitHub Actions. And git-chglog would be a good option for this.

## Notes

This workflow will run from the next tag. We need to manually create GitHub Releases for `v0.1.0` and `v0.2.0` before pushing a new tag.

To create the release notes, run the following commands:

```bash
$ git-chglog v0.1.0
$ git-chglog v0.2.0
```