### PR TITLE
feat(security): change UID/GID to 10111

### DIFF
--- a/core/clouddriver/base/deployment.yml
+++ b/core/clouddriver/base/deployment.yml
@@ -42,7 +42,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111

--- a/core/echo/base/deployment.yml
+++ b/core/echo/base/deployment.yml
@@ -42,7 +42,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111

--- a/core/front50/base/deployment.yml
+++ b/core/front50/base/deployment.yml
@@ -38,7 +38,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111

--- a/core/gate/base/deployment.yml
+++ b/core/gate/base/deployment.yml
@@ -45,7 +45,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111

--- a/core/igor/base/deployment.yml
+++ b/core/igor/base/deployment.yml
@@ -38,7 +38,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111

--- a/core/orca/base/deployment.yml
+++ b/core/orca/base/deployment.yml
@@ -38,7 +38,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111

--- a/core/rosco/base/deployment.yml
+++ b/core/rosco/base/deployment.yml
@@ -38,7 +38,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111

--- a/fiat/base/deployment.yml
+++ b/fiat/base/deployment.yml
@@ -42,7 +42,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111

--- a/kayenta/base/deployment.yml
+++ b/kayenta/base/deployment.yml
@@ -42,7 +42,7 @@ spec:
         secret:
           secretName: spinnaker-secrets
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10111
+        runAsGroup: 10111
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 10111


### PR DESCRIPTION
(Breaking Change) All Spinnaker microservices (with the exception of Halyard and Deck) now have explicit GIDs/UIDs in their Dockerfile.

If you are using a version of the kustomization-base that includes this commit with a pre-1.22 version of Spinnaker, you will need to include a patch that sets the GID/UID to 1000 (or whatever you've set the GID/UID to in a custom Dockerfile).