### PR TITLE
fix(security): remove Deck security context block

### DIFF
--- a/core/deck/base/deployment.yml
+++ b/core/deck/base/deployment.yml
@@ -38,8 +38,3 @@ spec:
       - name: spinnaker-secrets-volume
         secret:
           secretName: spinnaker-secrets
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        runAsNonRoot: true
-        fsGroup: 1000


### PR DESCRIPTION
Resolves: https://github.com/spinnaker/kleat/issues/135

I should have removed this with the commit that changed all non-Deck services to use the new Spinnaker GID/UID ([PR](https://github.com/spinnaker/kustomization-base/pull/30)).

Plumpy determined that it would be non-trivial to update Deck's Dockerfile to use the new GID/UID and we decided to leave as-is for now. Any user building a custom Deck image can add a custom security context as a patch.