### PR TITLE
fix(docs): Update image tags in override example

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ the tag for each microservice to be `spinnaker-1.21.0`:
 ```yaml
 images:
   - name: us-docker.pkg.dev/spinnaker-community/docker/clouddriver
-    newTag: spinnaker-1.20.5
+    newTag: spinnaker-1.21.0
   - name: us-docker.pkg.dev/spinnaker-community/docker/deck
-    newTag: spinnaker-1.20.5
+    newTag: spinnaker-1.21.0
 # ...
 ```
 


### PR DESCRIPTION
## What

Fixed the example overridden image tags in the README guide.

## Why

The guide of overriding image tags in README says:

> For example, to deploy Spinnaker 1.21.0, override the tag for each microservice to be `spinnaker-1.21.0`:

https://github.com/micnncim/kustomization-base/blob/c4bbd5fef013a13c80cfbd5a39a85e78e6c4d168/README.md#L198-L200

However, the content of an example uses `1.20.5` rather than `1.21.0`.
