### PR TITLE
fix(docs): Fix unavailable link of kustomize guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ resources:
 - github.com/spinnaker/kustomization-base/core?ref=v0.1.0
 ```
 
-For further details, see [the guide of kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md).
+For further details, see the [documentation](https://kubectl.docs.kubernetes.io/references/kustomize/resource/) for the `resources` field.
 
 #### (Optional) Add any -local configs
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ resources:
 - github.com/spinnaker/kustomization-base/core?ref=v0.1.0
 ```
 
-For further details, see [kustomization.yaml · The Kubectl Book](https://kubectl.docs.kubernetes.io/pages/examples/kustomize.html).
+For further details, see [the guide of kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md).
 
 #### (Optional) Add any -local configs
 


### PR DESCRIPTION
The previous link (https://kubectl.docs.kubernetes.io/pages/examples/kustomize.html) is no longer available. Changed it to an alternative one (https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md).