### PR TITLE
chore(docs): Fix spinnaker-config reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Before you start, you will need:
 
 ### Instructions
 
-Fork the [spinnaker-config](https://github.com/ezimanyi/spinnaker-config)
+Fork the [spinnaker-config](https://github.com/spinnaker/spinnaker-config)
 repository, and clone this fork to your local machine. This repository contains
 a template kustomization that you will configure to deploy Spinnaker.
 


### PR DESCRIPTION
I never updated this after moving `spinnaker-config` to live under the `spinnaker` org.