### PR TITLE
Use name for container ports ref

### DIFF
--- a/monitoring/patches/shared/sidecar.yml
+++ b/monitoring/patches/shared/sidecar.yml
@@ -12,11 +12,12 @@ spec:
         image: us-docker.pkg.dev/spinnaker-community/docker/monitoring-daemon:spinnaker-master-latest-validated
         name: monitoring-daemon
         ports:
-        - containerPort: 8008
+        - name: http
+          containerPort: 8008
           protocol: TCP
         readinessProbe:
           tcpSocket:
-            port: 8008
+            port: http
         volumeMounts:
         - mountPath: /opt/spinnaker-monitoring/filters
           name: spinnaker-monitoring-filters-volume


### PR DESCRIPTION
## What
I added `name` in thecontaine ports in `.spec.template.spac.ports[]`.

## Why
To reduce the use of magical (port) numbers. If we use `name`, we only need to declare the port number once.